### PR TITLE
Add sample actions workflow with 2 repos checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         uses: actions/checkout@v2
         with:
             repository: vgaidarji/gitleaks-sample-config
-            token: ${{ secrets.GITHUB_ACCESS_TOKEN }} 
+            token: ${{ secrets.ACCESS_TOKEN }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,3 +11,6 @@ jobs:
         with:
             repository: vgaidarji/gitleaks-sample-config
             token: ${{ secrets.ACCESS_TOKEN }} 
+      - name: List files in current dir
+        run: |
+          ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: "Run gitleaks with config located in another remote repo"
+on: [push, pull_request]
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repo
+        uses: actions/checkout@v2
+      - name: Checkout remote gitleaks config
+        uses: actions/checkout@v2
+        with:
+            repository: vgaidarji/gitleaks-sample-config
+            token: ${{ secrets.GITHUB_ACCESS_TOKEN }} 


### PR DESCRIPTION
### What has been done
Added sample GitHub Actions workflow which checks out current repo and remote private repo with [gitleaks](https://github.com/zricethezav/gitleaks) configuration file.

Uses `secrets.ACCESS_TOKEN` for private repo checkout
![image](https://user-images.githubusercontent.com/3036347/96766702-276f2a00-13e4-11eb-96ef-fa221606cb40.png)


### How to test
1. Check actions build logs on GitHub and make sure current repo (public) and remote (private) repo is cloned fine