### PR TITLE
Use gitleaks action with external config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: Checkout current repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Checkout remote gitleaks config
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,12 @@ jobs:
         with:
             repository: vgaidarji/gitleaks-sample-config
             token: ${{ secrets.ACCESS_TOKEN }} 
-            path: external-config
+            path: .
       - name: Checkout current repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          path: main
+          path: .
       - name: List files in current dir
         run: |
           ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           cp external-config/.gitleaks.toml main/.gitleaks.toml
           cd main
+          ls -al
       - name: List files in current dir
         run: |
           ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,21 +4,14 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout remote gitleaks config
-        uses: actions/checkout@v2
-        with:
-            repository: vgaidarji/gitleaks-sample-config
-            token: ${{ secrets.ACCESS_TOKEN }} 
-            path: external-config
       - name: Checkout current repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          path: main
       - name: Copy external config to main repo & cd to main
         run: |
-          cp external-config/.gitleaks.toml main/.gitleaks.toml
-          cd main
+          git clone https://${secrets.ACCESS_TOKEN}:x-oauth-basic@github.com/vgaidarji/gitleaks-sample-config.git external-config
+          cp external-config/.gitleaks.toml .
           ls -al
           echo "Workspace dir $GITHUB_WORKSPACE"
       - name: List files in current dir

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,19 +4,18 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout current repo
-        uses: actions/checkout@v1
       - name: Checkout remote gitleaks config
         uses: actions/checkout@v2
         with:
             repository: vgaidarji/gitleaks-sample-config
             token: ${{ secrets.ACCESS_TOKEN }} 
+      - name: Checkout current repo
+        uses: actions/checkout@v1
       - name: List files in current dir
         run: |
           ls -al
           echo "Printing the gitleaks config to be used"
           echo "We want to make sure it's not matching the one predefined in gitleaks action https://github.com/zricethezav/gitleaks-action/blob/master/.gitleaks.toml"
           cat $GITHUB_WORKSPACE/.gitleaks.toml
-          echo "Printing same commits as gitleaks action will be using for leaks scan on PR"
       - name: gitleaks-action
         uses: zricethezav/gitleaks-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
           fetch-depth: 0
       - name: Copy external config to main repo & cd to main
         run: |
-          git clone https://${secrets.ACCESS_TOKEN}:x-oauth-basic@github.com/vgaidarji/gitleaks-sample-config.git external-config
+          `git clone https://${secrets.ACCESS_TOKEN}:x-oauth-basic@github.com/vgaidarji/gitleaks-sample-config.git external-config`
           cp external-config/.gitleaks.toml .
           ls -al
           echo "Workspace dir $GITHUB_WORKSPACE"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,16 @@ jobs:
         with:
             repository: vgaidarji/gitleaks-sample-config
             token: ${{ secrets.ACCESS_TOKEN }} 
-            path: .
+            path: external-config
       - name: Checkout current repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          path: .
+          path: main
+      - name: Copy external config to main repo & cd to main
+        run: |
+          cp external-config/.gitleaks.toml main/.gitleaks.toml
+          cd main
       - name: List files in current dir
         run: |
           ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           cp external-config/.gitleaks.toml main/.gitleaks.toml
           cd main
           ls -al
+          echo "Workspace dir $GITHUB_WORKSPACE"
       - name: List files in current dir
         run: |
           ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,8 @@ jobs:
           echo "Printing the gitleaks config to be used"
           echo "We want to make sure it's not matching the one predefined in gitleaks action https://github.com/zricethezav/gitleaks-action/blob/master/.gitleaks.toml"
           cat $GITHUB_WORKSPACE/.gitleaks.toml
+          echo "Printing same commits as gitleaks action will be using for leaks scan on PR"
+          git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF...remotes/origin/$GITHUB_HEAD_REF > commit_list.txt
+          cat commit_list.txt
       - name: gitleaks-action
         uses: zricethezav/gitleaks-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repo
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v1
       - name: Checkout remote gitleaks config
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,12 @@ jobs:
         with:
             repository: vgaidarji/gitleaks-sample-config
             token: ${{ secrets.ACCESS_TOKEN }} 
+            path: external-config
       - name: Checkout current repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: main
       - name: List files in current dir
         run: |
           ls -al

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,8 @@ jobs:
       - name: List files in current dir
         run: |
           ls -al
+          echo "Printing the gitleaks config to be used"
+          echo "We want to make sure it's not matching the one predefined in gitleaks action https://github.com/zricethezav/gitleaks-action/blob/master/.gitleaks.toml"
+          cat .gitleaks.toml
+      - name: gitleaks-action
+        uses: zricethezav/gitleaks-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,5 @@ jobs:
           echo "We want to make sure it's not matching the one predefined in gitleaks action https://github.com/zricethezav/gitleaks-action/blob/master/.gitleaks.toml"
           cat $GITHUB_WORKSPACE/.gitleaks.toml
           echo "Printing same commits as gitleaks action will be using for leaks scan on PR"
-          git --git-dir="$GITHUB_WORKSPACE/.git" log --left-right --cherry-pick --pretty=format:"%H" remotes/origin/$GITHUB_BASE_REF...remotes/origin/$GITHUB_HEAD_REF > commit_list.txt
-          cat commit_list.txt
       - name: gitleaks-action
         uses: zricethezav/gitleaks-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Copy external config to main repo & cd to main
+        env:
+          TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
-          `git clone https://${secrets.ACCESS_TOKEN}:x-oauth-basic@github.com/vgaidarji/gitleaks-sample-config.git external-config`
+          `git clone https://${TOKEN}:x-oauth-basic@github.com/vgaidarji/gitleaks-sample-config.git external-config`
           cp external-config/.gitleaks.toml .
           ls -al
           echo "Workspace dir $GITHUB_WORKSPACE"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,6 @@ jobs:
           ls -al
           echo "Printing the gitleaks config to be used"
           echo "We want to make sure it's not matching the one predefined in gitleaks action https://github.com/zricethezav/gitleaks-action/blob/master/.gitleaks.toml"
-          cat .gitleaks.toml
+          cat $GITHUB_WORKSPACE/.gitleaks.toml
       - name: gitleaks-action
         uses: zricethezav/gitleaks-action@master

--- a/file_with_secrets.txt
+++ b/file_with_secrets.txt
@@ -1,0 +1,7 @@
+-----BEGIN PRIVATE KEY-----
+BASE64 ENCODED DATA
+-----END PRIVATE KEY-----
+
+xoxb-111222333444-aaabbbcccdddeeefffggghhh
+
+AKIAAAAAAAAAAAAAAAAA

--- a/file_with_secrets.txt
+++ b/file_with_secrets.txt
@@ -1,8 +1,1 @@
------BEGIN PRIVATE KEY-----
-BASE64 ENCODED DATA
------END PRIVATE KEY-----
-
-xoxb-111222333444-aaabbbcccdddeeefffggghhh
-xoxb-111222333444-aaabbbcccdddeeefffgggzzz
-
-AKIAAAAAAAAAAAAAAAAA
+no secrets here

--- a/file_with_secrets.txt
+++ b/file_with_secrets.txt
@@ -3,5 +3,6 @@ BASE64 ENCODED DATA
 -----END PRIVATE KEY-----
 
 xoxb-111222333444-aaabbbcccdddeeefffggghhh
+xoxb-111222333444-aaabbbcccdddeeefffgggzzz
 
 AKIAAAAAAAAAAAAAAAAA


### PR DESCRIPTION
### What has been done
- Added sample file with secrets to use in gitleaks scan 
- Used gitleaks GitHub Action https://github.com/zricethezav/gitleaks-action
- Action workflow from current repo should be using 
custom remote gitleaks config (https://github.com/vgaidarji/gitleaks-sample-config/blob/24b4c4af6e17847d7e5f199734f35f8fe02d7714/.gitleaks.toml) 
instead of default config which comes with gitleaks action (https://github.com/zricethezav/gitleaks-action/blob/b68a9d001c2a3810a83235411055da085c0cee66/.gitleaks.toml)

This is a workaround solution to ➡️  https://github.com/zricethezav/gitleaks-action/issues/11


### How to test

0. Add sample secrets to any file (or modify existing `file_with_secrets.txt`)
e.g.
```
-----BEGIN PRIVATE KEY-----
BASE64 ENCODED DATA
-----END PRIVATE KEY-----

xoxb-111222333444-aaabbbcccdddeeefffggghhh
xoxb-111222333444-aaabbbcccdddeeefffgggzzz

AKIAAAAAAAAAAAAAAAAA
```

1. Trigger any actions build for current PR
2. Verify printed to console gitleaks config which is cloned to workspace
3. Make sure config used for gitleaks scan is the one which is cloned from remote (https://github.com/vgaidarji/gitleaks-sample-config/blob/24b4c4af6e17847d7e5f199734f35f8fe02d7714/.gitleaks.toml) and not default config (https://github.com/zricethezav/gitleaks-action/blob/b68a9d001c2a3810a83235411055da085c0cee66/.gitleaks.toml) 

➡️ See https://github.com/vgaidarji/gitleaks-action-external-config/pull/2#issuecomment-713860995 with testing results.
➡️ And it's ok that CI is 🔴, it's expected, see explanation in https://github.com/vgaidarji/gitleaks-action-external-config/pull/2#pullrequestreview-514171622.